### PR TITLE
fix: allow to run any command in the docker image

### DIFF
--- a/src/main/java/io/kestra/plugin/cloudquery/CloudQueryCLI.java
+++ b/src/main/java/io/kestra/plugin/cloudquery/CloudQueryCLI.java
@@ -94,8 +94,8 @@ public class CloudQueryCLI extends AbstractCloudQueryCommand implements Runnable
             .withCommands(
                 ScriptService.scriptCommands(
                     List.of("/bin/sh", "-c"),
-                    List.of(""),
-                    this.commands.stream().map(cmd -> "/app/cloudquery " + cmd).toList()
+                    List.of("alias cloudquery='/app/cloudquery'"),
+                    this.commands
                 )
             )
             .withEnv(this.getEnv());

--- a/src/test/java/io/kestra/plugin/cloudquery/CloudQueryCLITest.java
+++ b/src/test/java/io/kestra/plugin/cloudquery/CloudQueryCLITest.java
@@ -33,7 +33,10 @@ class CloudQueryCLITest {
             .type(CloudQueryCLI.class.getName())
             .env(Map.of("{{ inputs.envKey }}", "{{ inputs.envValue }}"))
             .commands(List.of(
-                "--version --log-console"
+                "echo \"::{\\\"outputs\\\":{" +
+                    "\\\"customEnv\\\":\\\"$" + envKey + "\\\"" +
+                    "}}::\"",
+                "cloudquery --version --log-console"
             ))
             .build();
 
@@ -42,5 +45,7 @@ class CloudQueryCLITest {
         ScriptOutput runOutput = execute.run(runContext);
 
         assertThat(runOutput.getExitCode(), is(0));
+        assertThat(runOutput.getVars().get("customEnv"), is(envValue));
+
     }
 }


### PR DESCRIPTION
remove entry point and add an alias for cloudquery as it's not in the $PATH

closes #10 