### PR TITLE
fix(sync): config render type in no-code

### DIFF
--- a/src/main/java/io/kestra/plugin/cloudquery/Sync.java
+++ b/src/main/java/io/kestra/plugin/cloudquery/Sync.java
@@ -104,7 +104,7 @@ public class Sync extends AbstractCloudQueryCommand implements RunnableTask<Scri
     @Schema(
         title = "CloudQuery configurations.",
         description = "A list of CloudQuery configurations or files containing CloudQuery configurations.",
-        anyOf = {String[].class, Map[].class}
+        anyOf = { String.class, List.class, Map.class }
     )
     @PluginProperty
     @NotNull


### PR DESCRIPTION
closes #101 

<img width="572" height="394" alt="Screenshot 2025-08-25 at 11 10 49 PM" src="https://github.com/user-attachments/assets/86e02117-9548-4a5a-9543-041db9cb32ff" />
