### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/cloudquery/AbstractCloudQueryCommand.java
+++ b/src/main/java/io/kestra/plugin/cloudquery/AbstractCloudQueryCommand.java
@@ -28,6 +28,7 @@ abstract class AbstractCloudQueryCommand extends Task {
         description = "Key-value pairs rendered by Kestra and passed to the CloudQuery process; empty by default."
     )
     @PluginProperty(group = "execution")
+    @ToString.Exclude
     protected Property<Map<String, String>> env;
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Credential env map included in Lombok @ToString output (`src/main/java/io/kestra/plugin/cloudquery/AbstractCloudQueryCommand.java:31`)
  - Fix: Added `@ToString.Exclude` to the `env` field in `AbstractCloudQueryCommand` to prevent secrets (CLOUDQUERY_API_KEY, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc.) from being serialized into log output via Lombok's generated `toString()` method. Since `Sync` and `CloudQueryCLI` both extend `AbstractCloudQueryCommand`, this single fix protects all subclasses.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-cloudquery/issues/169
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
