### PR TITLE
docs(cloudquery): correctness and completeness pass on task docs

### DIFF
--- a/src/main/java/io/kestra/plugin/cloudquery/CloudQueryCLI.java
+++ b/src/main/java/io/kestra/plugin/cloudquery/CloudQueryCLI.java
@@ -61,15 +61,15 @@ import io.kestra.core.models.annotations.PluginProperty;
                           spec:
                             item_concurrency: 100
                             start_time: "{{ now() | dateAdd(-1, 'DAYS') }}"
-                          ---
-                          kind: destination
+                        ---
+                        kind: destination
+                        spec:
+                          name: duckdb
+                          path: cloudquery/duckdb
+                          version: v4.2.10
+                          write_mode: overwrite-delete-stale
                           spec:
-                            name: duckdb
-                            path: cloudquery/duckdb
-                            version: v4.2.10
-                            write_mode: overwrite-delete-stale
-                            spec:
-                              connection_string: hn.db
+                            connection_string: hn.db
                     commands:
                       - cloudquery sync config.yml --log-console"""
         )

--- a/src/main/java/io/kestra/plugin/cloudquery/package-info.java
+++ b/src/main/java/io/kestra/plugin/cloudquery/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "CloudQuery",
     description = "This sub-group of plugins contains tasks for using CloudQuery CLI.",
     categories = { PluginSubGroup.PluginCategory.DATA }
 )

--- a/src/main/resources/doc/io.kestra.plugin.cloudquery.md
+++ b/src/main/resources/doc/io.kestra.plugin.cloudquery.md
@@ -10,4 +10,4 @@ Pass credentials via the `env` map — at minimum set `CLOUDQUERY_API_KEY` (requ
 
 `Sync` runs a CloudQuery sync from a set of source/destination configs — set `configs` (required, a list of CloudQuery source and destination configuration objects). Set `incremental: true` to persist state between runs (default `false`). The task runs in a container (default image `ghcr.io/cloudquery/cloudquery:latest-ubuntu`). Use `namespaceFiles` to reference [namespace files](https://kestra.io/docs/concepts/namespace-files), `inputFiles` to stage additional files, and `outputFiles` to retrieve results.
 
-`CloudQueryCLI` runs arbitrary CloudQuery CLI commands — set `commands` (required). Use `beforeCommands`, `env`, `namespaceFiles`, `inputFiles`, and `outputFiles` the same way as `Sync`.
+`CloudQueryCLI` runs arbitrary CloudQuery CLI commands — set `commands` (required). Use `env`, `namespaceFiles`, `inputFiles`, and `outputFiles` the same way as `Sync`.


### PR DESCRIPTION
## Documentation review: plugin-cloudquery

Task-level doc pass over the two tasks (`Sync`, `CloudQueryCLI`), the shared `AbstractCloudQueryCommand`, `index.yaml`, and the how-to doc. Documentation only; no runtime behavior changes.

### Fixes
- **`package-info.java`** — `@PluginSubGroup` was missing the `title` attribute → added `"CloudQuery"` (matches `index.yaml`).
- **how-to doc** — the `CloudQueryCLI` entry told users to set `beforeCommands`, but that is not a property on the task (the `alias cloudquery=…` before-command is applied internally; there is no user-settable `beforeCommands`) → removed it from the list.
- **`CloudQueryCLI` example** — the inline `config.yml` block scalar placed the `---` multi-document separator and the entire `destination` document indented under the source's `spec`. After the block scalar is de-indented, the `---` lands at column 2 (not a valid YAML document separator) and the destination document is nested incorrectly, so the config would fail to parse. Realigned the `---` and destination document to the top level of the file.

`Sync`'s two examples, `AbstractCloudQueryCommand` (env/docker/taskRunner/containerImage all documented, `docker` correctly marked deprecated), `index.yaml`, and the how-to Authentication section were all accurate. No `@Metric` declared or emitted; secrets use `{{ secret('...') }}` throughout. No code-level flags.